### PR TITLE
fix get and show data list users

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -27,14 +27,18 @@ class UserController extends Controller
             'users.email',
             'users.is_admin',
             'users.avatar_url',
+            DB::raw('COUNT(DISTINCT(books.id)) AS books_donated_count'),
+            DB::raw('COUNT(DISTINCT(borrows.book_id)) AS books_borrowed_count'),
         ];
         $users = User::select($fields)
-        ->withCount(['books', 'borrows'])
-        ->orderBy('id')
+        ->leftJoin('books', 'users.employ_code', '=', 'books.from_person')
+        ->leftJoin('borrows', 'users.id', '=', 'borrows.user_id')
+        ->groupBy('users.id')
         ->paginate(config('define.users.limit_rows'));
 
         return view('backend.users.index', ['users' => $users]);
     }
+
      /**
      * Display the profile of user.
      *
@@ -62,7 +66,6 @@ class UserController extends Controller
 
         return view('backend.users.show', ['user' => $user]);
     }
-
 
     /**
      * Update role user.

--- a/resources/lang/en/users.php
+++ b/resources/lang/en/users.php
@@ -8,7 +8,7 @@ return [
     'employee_code' => 'Employee Code',
     'name' => 'Name',
     'email' => 'Email',
-    'donate' => 'Donate',
+    'donate' => 'Donated',
     'borrowed' => 'Borrowed',
     'detail_user' => 'Detail User',
     'user_profile' => 'User Profile',

--- a/resources/views/backend/users/index.blade.php
+++ b/resources/views/backend/users/index.blade.php
@@ -30,12 +30,12 @@
               <table id="example2" class="table table-bordered table-hover">
                 <thead>
                  <tr>
-                  <th>{{ __('users.no') }}</th>
-                  <th>{{ __('users.employee_code') }}</th>
-                  <th>{{ __('users.name') }}</th>
-                  <th>{{ __('users.email') }}</th>
-                  <th>{{ __('users.donate') }}</th>
-                  <th>{{ __('users.borrowed') }}</th>
+                  <th class="text-center">{{ __('users.no') }}</th>
+                  <th class="text-center">{{ __('users.employee_code') }}</th>
+                  <th class="text-center">{{ __('users.name') }}</th>
+                  <th class="text-center">{{ __('users.email') }}</th>
+                  <th class="text-center">{{ __('users.donate') }}</th>
+                  <th class="text-center">{{ __('users.borrowed') }}</th>
                   @if(Auth::user()->team == __('users.admin_team_name'))
                     <th class="text-center">{{ __('users.role') }}</th>
                   @endif
@@ -44,12 +44,12 @@
                 <tbody>
                 @foreach ($users as $index => $user)
                   <tr>
-                    <td>{{ $index + $users->firstItem() }}</td>
-                    <td>{{ $user->employ_code }}</td>
+                    <td class="text-center">{{ $index + $users->firstItem() }}</td>
+                    <td class="text-center">{{ $user->employ_code }}</td>
                     <td><a href="{{ route('users.show', ['id' => $user->id]) }}">{{ $user->name }}</a></td>
                     <td>{{ $user->email }}</td>
-                    <td><a href="{{ route('books.index', ['userid' => $user->id, 'option' => 'donated']) }}">{{ $user->books_count }}</a></td>
-                    <td><a href="{{ route('books.index', ['userid' => $user->id, 'option' => 'borrowed']) }}">{{ $user->borrows_count }}</a></td>
+                    <td class="text-center"><a href="{{ route('books.index', ['userid' => $user->id, 'option' => 'donated']) }}">{{ $user->books_donated_count }}</a></td>
+                    <td class="text-center"><a href="{{ route('books.index', ['userid' => $user->id, 'option' => 'borrowed']) }}">{{ $user->books_borrowed_count }}</a></td>
                     @if(Auth::user()->team == __('users.admin_team_name'))
                       <td class="text-center"><button type="button" name="btn-role" id="role-user-{{ $user->id }}" data-id="{{ $user->id }}" style="width: 45px" {{$user->team == __('users.admin_team_name') ? 'disabled' : '' }}
                       @if($user->is_admin == __('users.role_user'))


### PR DESCRIPTION
## Description
List off Users,Can see No., Employee code, Name, email, number of books user donate, number of books user borrowed.
## Reference Requirements
- Product Backlog ID: #PBI-10
- Task ID: #10.2

## Reference Isuees
Non

## Migrations
NO

## Impacted Areas in Application
List general components of the application that this PR will affect:

-

## SQL query and `explain`
select * from `users` where `id` = '11' and `users`.`deleted_at` is null limit 1
![image](https://user-images.githubusercontent.com/33870071/35138016-ebfbcebc-fd1e-11e7-91fa-98ec9b00c55c.png)
select count(*) as aggregate from `users` left join `books` on `users`.`employ_code` = `books`.`from_person` left join `borrows` on `users`.`id` = `borrows`.`user_id` where `users`.`deleted_at` is null group by `users`.`id`
![image](https://user-images.githubusercontent.com/33870071/35138119-8e1cefb4-fd1f-11e7-98f6-a75c0b2443f2.png)
select `users`.`id`, `users`.`employ_code`, `users`.`name`, `users`.`team`, `users`.`email`, `users`.`is_admin`, `users`.`avatar_url`, COUNT(DISTINCT(books.id)) AS books_donated_count, COUNT(DISTINCT(borrows.book_id)) AS books_borrowed_count from `users` left join `books` on `users`.`employ_code` = `books`.`from_person` left join `borrows` on `users`.`id` = `borrows`.`user_id` where `users`.`deleted_at` is null group by `users`.`id` limit 10 offset 0
![image](https://user-images.githubusercontent.com/33870071/35138143-aece055e-fd1f-11e7-9630-7919716b6582.png)


- Refer to [Using Explain with MySQL](https://viblo.asia/p/su-dung-explain-de-toi-uu-cau-lenh-mysql-BYjv44gmvxpV)
